### PR TITLE
Replace validator engine with @jsonlint/core; add error-code pages + sample telemetry

### DIFF
--- a/app/errors/[code]/page.tsx
+++ b/app/errors/[code]/page.tsx
@@ -1,0 +1,196 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ToolNav } from '@/components/ToolNav';
+import { Container } from '@/components/Container';
+import {
+  getAllErrorCodes,
+  getErrorCode,
+  type ErrorCodeEntry,
+} from '@/lib/error-codes';
+
+interface PageProps {
+  params: { code: string };
+}
+
+export function generateStaticParams() {
+  return getAllErrorCodes().map((e) => ({ code: e.code }));
+}
+
+export function generateMetadata({ params }: PageProps): Metadata {
+  const entry = getErrorCode(params.code);
+  if (!entry) {
+    return { title: 'Unknown JSON error code' };
+  }
+  const label = entry.severity === 'error' ? 'Error' : 'Warning';
+  const title = `${entry.code}: ${entry.title} — JSON ${label}`;
+  const description = `${entry.summary} Learn what JSON ${entry.code} means, see an example, and how to fix it.`;
+  return {
+    title,
+    description,
+    keywords: [
+      entry.code,
+      `json ${entry.code}`,
+      `${entry.code} json error`,
+      entry.title.toLowerCase(),
+      'json error',
+      'json validator',
+    ],
+    openGraph: { title, description },
+    alternates: { canonical: `https://jsonlint.com/errors/${entry.code}` },
+  };
+}
+
+function CodeBlock({
+  label,
+  tone,
+  children,
+}: {
+  label: string;
+  tone: 'bad' | 'good';
+  children: string;
+}) {
+  const color = tone === 'bad' ? 'text-accent-red' : 'text-accent-green';
+  const bg =
+    tone === 'bad' ? 'rgba(239, 68, 68, 0.08)' : 'rgba(16, 185, 129, 0.08)';
+  return (
+    <div>
+      <div className={`text-xs font-medium mb-1 ${color}`}>{label}</div>
+      <pre
+        className="text-sm font-mono overflow-x-auto rounded-md px-3 py-2 m-0"
+        style={{ background: bg, color: 'var(--text-secondary)' }}
+      >
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+export default function ErrorCodePage({ params }: PageProps) {
+  const entry: ErrorCodeEntry | null = getErrorCode(params.code);
+  if (!entry) notFound();
+
+  const isError = entry.severity === 'error';
+  const badgeColor = isError ? 'text-accent-red' : 'text-accent-amber';
+
+  return (
+    <>
+      <ToolNav />
+
+      <Container className="py-4">
+        <nav className="text-xs mb-4" style={{ color: 'var(--text-muted)' }}>
+          <Link href="/errors" className="hover:underline">
+            JSON error codes
+          </Link>{' '}
+          / {entry.code}
+        </nav>
+
+        <div className="flex flex-wrap items-center gap-2 mb-2">
+          <span
+            className={`font-mono text-sm px-2 py-0.5 rounded ${badgeColor}`}
+            style={{ background: 'var(--bg-tertiary)' }}
+          >
+            {entry.code}
+          </span>
+          <span
+            className={`text-xs uppercase tracking-wide ${badgeColor}`}
+          >
+            {isError ? 'Error' : 'Warning'}
+          </span>
+        </div>
+
+        <h1
+          className="text-2xl font-bold mb-2"
+          style={{ color: 'var(--text-primary)' }}
+        >
+          {entry.title}
+        </h1>
+        <p className="text-sm mb-6" style={{ color: 'var(--text-muted)' }}>
+          {entry.summary}
+        </p>
+
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr,280px] gap-6">
+          <div className="prose-custom max-w-none">
+            <h2>What it means</h2>
+            <p>{entry.explanation}</p>
+
+            <h2>Example</h2>
+            <div className="space-y-3 not-prose">
+              <CodeBlock label="Invalid" tone="bad">
+                {entry.example.bad}
+              </CodeBlock>
+              {entry.example.good && (
+                <CodeBlock label="Valid" tone="good">
+                  {entry.example.good}
+                </CodeBlock>
+              )}
+            </div>
+
+            <h2>How to fix it</h2>
+            <p>{entry.fix}</p>
+
+            <p>
+              <Link href="/">Validate your JSON</Link> to see this and every
+              other issue highlighted in one pass.
+            </p>
+
+            <hr />
+            <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+              Diagnostics on this page come from{' '}
+              <a
+                href="https://www.npmjs.com/package/@jsonlint/core"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                @jsonlint/core
+              </a>
+              , the open-source engine that powers the JSONLint validator.
+              Install it with <code>npm install @jsonlint/core</code>.
+            </p>
+          </div>
+
+          <aside className="lg:pt-1">
+            <div
+              className="rounded-lg p-4 text-sm"
+              style={{
+                background: 'var(--bg-secondary)',
+                border: '1px solid var(--border-primary)',
+              }}
+            >
+              <div
+                className="font-medium mb-2"
+                style={{ color: 'var(--text-primary)' }}
+              >
+                Other codes
+              </div>
+              <ul className="space-y-1 list-none p-0 m-0">
+                {getAllErrorCodes()
+                  .filter((e) => e.code !== entry.code)
+                  .slice(0, 12)
+                  .map((e) => (
+                    <li key={e.code}>
+                      <Link
+                        href={`/errors/${e.code}`}
+                        className="hover:underline"
+                        style={{ color: 'var(--text-secondary)' }}
+                      >
+                        <span className="font-mono text-xs">{e.code}</span> —{' '}
+                        {e.title}
+                      </Link>
+                    </li>
+                  ))}
+              </ul>
+              <Link
+                href="/errors"
+                className="inline-block mt-3 text-xs"
+                style={{ color: 'var(--accent-blue)' }}
+              >
+                View all error codes →
+              </Link>
+            </div>
+          </aside>
+        </div>
+      </Container>
+    </>
+  );
+}

--- a/app/errors/page.tsx
+++ b/app/errors/page.tsx
@@ -1,0 +1,142 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { ToolNav } from '@/components/ToolNav';
+import { Container } from '@/components/Container';
+import { getAllErrorCodes } from '@/lib/error-codes';
+
+export const metadata: Metadata = {
+  title: 'JSON Error Codes — Reference & Fixes',
+  description:
+    'A complete reference for every JSON validation error and warning: what each code means, an example, and how to fix it. Powered by @jsonlint/core.',
+  keywords: [
+    'json error codes',
+    'json validation errors',
+    'json syntax error',
+    'json parse error',
+    'fix json error',
+    'json error reference',
+  ],
+  openGraph: {
+    title: 'JSON Error Codes — Reference & Fixes',
+    description:
+      'Every JSON validation error and warning explained, with examples and fixes.',
+  },
+  alternates: { canonical: 'https://jsonlint.com/errors' },
+};
+
+export default function ErrorsIndexPage() {
+  const all = getAllErrorCodes();
+  const errors = all.filter((e) => e.severity === 'error');
+  const warnings = all.filter((e) => e.severity === 'warning');
+
+  const Section = ({
+    title,
+    subtitle,
+    items,
+    tone,
+  }: {
+    title: string;
+    subtitle: string;
+    items: typeof all;
+    tone: 'error' | 'warning';
+  }) => {
+    const color = tone === 'error' ? 'text-accent-red' : 'text-accent-amber';
+    return (
+      <section className="mb-8">
+        <h2
+          className="text-lg font-semibold mb-1"
+          style={{ color: 'var(--text-primary)' }}
+        >
+          {title}
+        </h2>
+        <p className="text-sm mb-3" style={{ color: 'var(--text-muted)' }}>
+          {subtitle}
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {items.map((e) => (
+            <Link
+              key={e.code}
+              href={`/errors/${e.code}`}
+              className="flex items-start gap-2 rounded-md px-3 py-2 transition-colors"
+              style={{
+                background: 'var(--bg-secondary)',
+                border: '1px solid var(--border-primary)',
+              }}
+            >
+              <span
+                className={`font-mono text-xs px-1.5 py-0.5 rounded flex-shrink-0 ${color}`}
+                style={{ background: 'var(--bg-tertiary)' }}
+              >
+                {e.code}
+              </span>
+              <span className="min-w-0">
+                <span
+                  className="text-sm font-medium"
+                  style={{ color: 'var(--text-primary)' }}
+                >
+                  {e.title}
+                </span>
+                <span
+                  className="block text-xs"
+                  style={{ color: 'var(--text-muted)' }}
+                >
+                  {e.summary}
+                </span>
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+    );
+  };
+
+  return (
+    <>
+      <ToolNav />
+
+      <Container className="py-4">
+        <h1
+          className="text-2xl font-bold mb-2"
+          style={{ color: 'var(--text-primary)' }}
+        >
+          JSON Error Codes
+        </h1>
+        <p className="text-sm mb-6 max-w-2xl" style={{ color: 'var(--text-muted)' }}>
+          Every diagnostic the JSONLint validator can report, with a plain-English
+          explanation, an example, and how to fix it. Paste your JSON into the{' '}
+          <Link href="/" style={{ color: 'var(--accent-blue)' }}>
+            validator
+          </Link>{' '}
+          to see all of these at once, each linked to its reference page.
+        </p>
+
+        <Section
+          title="Errors"
+          subtitle="These make the document invalid — it will not parse until they are fixed."
+          items={errors}
+          tone="error"
+        />
+        <Section
+          title="Warnings"
+          subtitle="The document is still valid JSON, but these are common sources of bugs."
+          items={warnings}
+          tone="warning"
+        />
+
+        <p className="text-sm mt-4" style={{ color: 'var(--text-muted)' }}>
+          These codes are produced by{' '}
+          <a
+            href="https://www.npmjs.com/package/@jsonlint/core"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--accent-blue)' }}
+          >
+            @jsonlint/core
+          </a>
+          , the open-source engine behind JSONLint. Run the same checks in your own
+          tooling with <code>npm install @jsonlint/core</code>.
+        </p>
+      </Container>
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from 'next';
 import fs from 'fs';
 import path from 'path';
+import { getAllErrorCodes } from '@/lib/error-codes';
 
 function getAllMarkdownSlugs(dir: string, basePath: string = ''): string[] {
   if (!fs.existsSync(dir)) return [];
@@ -98,5 +99,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.6,
   }));
 
-  return [...staticEntries, ...contentEntries, ...datasetEntries];
+  // Error-code reference pages
+  const errorEntries: MetadataRoute.Sitemap = [
+    {
+      url: `${baseUrl}/errors`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+    ...getAllErrorCodes().map((e) => ({
+      url: `${baseUrl}/errors/${e.code}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.6,
+    })),
+  ];
+
+  return [
+    ...staticEntries,
+    ...contentEntries,
+    ...datasetEntries,
+    ...errorEntries,
+  ];
 }

--- a/components/JsonValidator.tsx
+++ b/components/JsonValidator.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import Link from 'next/link';
 import { LazyJsonEditor as JsonEditor } from './LazyJsonEditor';
 import { useValidation } from './ValidationContext';
 import {
@@ -12,6 +13,8 @@ import {
   sortJSONKeys,
   tryFixJSON,
 } from '@/lib/json-utils';
+import { lint, type LintDiagnostic } from '@/lib/jsonlint-core-integration';
+import { recordValidationSample } from '@/lib/shadow-telemetry';
 
 const SAMPLE_JSON = `{
   "name": "John Doe",
@@ -41,8 +44,7 @@ export function JsonValidator({ initialJson, initialUrl }: JsonValidatorProps) {
   const [input, setInput] = useState('');
   const [isFormatted, setIsFormatted] = useState(true);
   const [copied, setCopied] = useState(false);
-  const [errorHint, setErrorHint] = useState<string | null>(null);
-  const [warning, setWarning] = useState<string | null>(null);
+  const [diagnostics, setDiagnostics] = useState<LintDiagnostic[]>([]);
   const [indentOption, setIndentOption] = useState<IndentOption>('2');
   const containerRef = useRef<HTMLDivElement>(null);
   const { status, setStatus, errorMessage, setErrorMessage, errorLine, setErrorLine } =
@@ -97,28 +99,33 @@ export function JsonValidator({ initialJson, initialUrl }: JsonValidatorProps) {
         setStatus('idle');
         setErrorMessage(null);
         setErrorLine(null);
-        setErrorHint(null);
-        setWarning(null);
+        setDiagnostics([]);
         return;
       }
 
-      const result = parseJSON(jsonToValidate);
+      // Validated by @jsonlint/core: a single pass returns every error and
+      // warning at once, each with a precise line/column. See
+      // lib/jsonlint-core-integration.ts.
+      const result = lint(jsonToValidate);
+      setDiagnostics(result.diagnostics);
 
-      if (result.valid) {
+      // Sampled, document-free telemetry (code frequency + engine latency).
+      // See lib/shadow-telemetry.ts.
+      recordValidationSample(result, jsonToValidate.length);
+
+      const firstError = result.diagnostics.find((d) => d.severity === 'error');
+
+      if (result.ok) {
         setStatus('valid');
         setErrorMessage(null);
         setErrorLine(null);
-        setErrorHint(null);
-        setWarning(result.warning || null);
         // Don't auto-format - preserve original input to maintain number formatting (e.g., 1.0 vs 1)
         // User can click "Prettify" to format if desired
         setIsFormatted(detectFormat(jsonToValidate) === 'formatted');
       } else {
         setStatus('invalid');
-        setErrorMessage(result.error || 'Invalid JSON');
-        setErrorLine(result.line || null);
-        setErrorHint(result.hint || null);
-        setWarning(null);
+        setErrorMessage(firstError?.message || 'Invalid JSON');
+        setErrorLine(firstError?.line || null);
       }
     },
     [input, setStatus, setErrorMessage, setErrorLine]
@@ -150,6 +157,7 @@ export function JsonValidator({ initialJson, initialUrl }: JsonValidatorProps) {
     setStatus('idle');
     setErrorMessage(null);
     setErrorLine(null);
+    setDiagnostics([]);
   };
 
   const handleSort = () => {
@@ -184,6 +192,8 @@ export function JsonValidator({ initialJson, initialUrl }: JsonValidatorProps) {
 
   const stats = status === 'valid' ? getJSONStats(input) : null;
   const format = detectFormat(input);
+  const errors = diagnostics.filter((d) => d.severity === 'error');
+  const warnings = diagnostics.filter((d) => d.severity === 'warning');
 
   return (
     <div className="space-y-3">
@@ -294,15 +304,14 @@ export function JsonValidator({ initialJson, initialUrl }: JsonValidatorProps) {
               </span>
             )}
           </div>
-          {warning && (
+          {warnings.length > 0 && (
             <div
-              className="flex items-start gap-2 px-3 py-2 rounded-md text-sm animate-fade-in"
-              style={{
-                background: 'rgba(245, 158, 11, 0.1)',
-              }}
+              className="space-y-3 px-3 py-2 rounded-md animate-fade-in"
+              style={{ background: 'rgba(245, 158, 11, 0.1)' }}
             >
-              <WarningIcon className="w-4 h-4 text-accent-amber flex-shrink-0 mt-0.5" />
-              <span style={{ color: 'var(--text-secondary)' }}>{warning}</span>
+              {warnings.map((d, i) => (
+                <DiagnosticCard key={`w${i}`} d={d} sourceText={input} />
+              ))}
             </div>
           )}
         </div>
@@ -310,54 +319,134 @@ export function JsonValidator({ initialJson, initialUrl }: JsonValidatorProps) {
 
       {status === 'invalid' && (
         <div
-          className="px-3 py-2 rounded-md animate-fade-in"
+          className="space-y-3 px-3 py-2 rounded-md animate-fade-in"
           style={{
             background: 'rgba(239, 68, 68, 0.1)',
           }}
         >
-          <div className="flex items-start gap-2">
-            <XCircleIcon className="w-4 h-4 text-accent-red flex-shrink-0 mt-0.5" />
-            <div className="min-w-0">
-              <span className="font-medium text-accent-red text-sm">Invalid JSON</span>
-              {errorMessage && (
-                <pre
-                  className="mt-1 text-xs font-mono overflow-x-auto"
-                  style={{ color: 'var(--text-secondary)' }}
-                >
-                  {errorMessage}
-                  {errorLine && (
-                    <span className="text-accent-amber ml-2">
-                      (Line {errorLine})
-                    </span>
-                  )}
-                </pre>
-              )}
-              {errorHint && (
-                <p
-                  className="mt-2 text-xs"
-                  style={{ color: 'var(--text-secondary)' }}
-                >
-                  <LightBulbIcon className="w-3.5 h-3.5 inline-block mr-1 text-accent-amber" />
-                  {errorHint.includes('JSONC to JSON tool') ? (
-                    <>
-                      {errorHint.replace('JSONC to JSON tool', '')}
-                      <a
-                        href="/jsonc-to-json"
-                        className="text-accent-blue hover:underline"
-                      >
-                        JSONC to JSON tool
-                      </a>
-                      .
-                    </>
-                  ) : (
-                    errorHint
-                  )}
-                </p>
-              )}
-            </div>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <XCircleIcon className="w-4 h-4 text-accent-red flex-shrink-0" />
+            <span className="font-medium text-accent-red text-sm">Invalid JSON</span>
+            <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+              {errors.length} error{errors.length === 1 ? '' : 's'}
+              {warnings.length > 0 &&
+                ` • ${warnings.length} warning${warnings.length === 1 ? '' : 's'}`}
+            </span>
+          </div>
+          <div className="space-y-3">
+            {errors.map((d, i) => (
+              <DiagnosticCard key={`e${i}`} d={d} sourceText={input} />
+            ))}
+            {warnings.map((d, i) => (
+              <DiagnosticCard key={`w${i}`} d={d} sourceText={input} />
+            ))}
           </div>
         </div>
       )}
+
+      {/* Powered by @jsonlint/core — the engine behind this validator */}
+      <div
+        className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs pt-1"
+        style={{ color: 'var(--text-muted)' }}
+      >
+        <span>
+          Validated by{' '}
+          <a
+            href="https://github.com/toddynho/jsonlint-core"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            @jsonlint/core
+          </a>
+        </span>
+        <span aria-hidden="true">·</span>
+        <code
+          className="px-1.5 py-0.5 rounded font-mono"
+          style={{ background: 'var(--bg-tertiary)' }}
+        >
+          npm install @jsonlint/core
+        </code>
+        <span aria-hidden="true">·</span>
+        <Link
+          href="/errors"
+          className="hover:underline"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          Error code reference
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+const JSONC_CODES = new Set(['E008', 'E020', 'E021']);
+
+function DiagnosticCard({
+  d,
+  sourceText,
+}: {
+  d: LintDiagnostic;
+  sourceText: string;
+}) {
+  const isError = d.severity === 'error';
+  const color = isError ? 'text-accent-red' : 'text-accent-amber';
+  const srcLine = sourceText.split(/\r\n|\r|\n/)[d.line - 1] ?? '';
+  const caret =
+    ' '.repeat(Math.min(Math.max(d.column - 1, 0), 200)) + '^';
+
+  return (
+    <div className="flex items-start gap-2">
+      {isError ? (
+        <XCircleIcon className={`w-4 h-4 ${color} flex-shrink-0 mt-0.5`} />
+      ) : (
+        <WarningIcon className={`w-4 h-4 ${color} flex-shrink-0 mt-0.5`} />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-sm">
+          <Link
+            href={`/errors/${d.code}`}
+            className={`font-mono text-xs px-1.5 py-0.5 rounded hover:underline ${color}`}
+            style={{ background: 'var(--bg-tertiary)' }}
+            title={`What does ${d.code} mean?`}
+          >
+            {d.code}
+          </Link>
+          <span style={{ color: 'var(--text-secondary)' }}>{d.message}</span>
+          <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+            line {d.line}, col {d.column}
+          </span>
+        </div>
+        {srcLine && (
+          <pre
+            className="mt-1 text-xs font-mono overflow-x-auto"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            {srcLine.slice(0, 200)}
+            {'\n'}
+            {caret}
+          </pre>
+        )}
+        {d.related && (
+          <p className="mt-1 text-xs" style={{ color: 'var(--text-muted)' }}>
+            first occurrence at line {d.related.line}, col {d.related.column}
+          </p>
+        )}
+        {d.hint && (
+          <p className="mt-1 text-xs" style={{ color: 'var(--text-secondary)' }}>
+            <LightBulbIcon className="w-3.5 h-3.5 inline-block mr-1 text-accent-amber" />
+            {d.hint}
+          </p>
+        )}
+        {JSONC_CODES.has(d.code) && (
+          <p className="mt-1 text-xs">
+            <a href="/jsonc-to-json" className="text-accent-blue hover:underline">
+              Convert with the JSONC to JSON tool
+            </a>
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/SeoContent.tsx
+++ b/components/SeoContent.tsx
@@ -219,7 +219,24 @@ export function SeoContent() {
 
       <h2>Credits</h2>
       <p>
-        Maintained by CircleCell. Thanks to{' '}
+        Maintained by{' '}
+        <a href="https://x.com/toddo" target="_blank" rel="noopener">
+          Todd Garland
+        </a>
+        . Validation is now powered by{' '}
+        <a
+          href="https://github.com/toddynho/jsonlint-core"
+          target="_blank"
+          rel="noopener"
+        >
+          @jsonlint/core
+        </a>
+        , our open-source single-pass JSON engine that reports every error and
+        warning at once — install it with{' '}
+        <code>npm install @jsonlint/core</code>.
+      </p>
+      <p>
+        Thanks to{' '}
         <a href="http://www.crockford.com/" target="_blank" rel="noopener">
           Douglas Crockford
         </a>{' '}
@@ -227,15 +244,15 @@ export function SeoContent() {
         <a href="http://zaa.ch/" target="_blank" rel="noopener">
           Zach Carter
         </a>
-        , who built a{' '}
+        , who built the original{' '}
         <a
           href="https://github.com/zaach/jsonlint"
           target="_blank"
           rel="noopener"
         >
           pure JavaScript implementation
-        </a>
-        . You can download the{' '}
+        </a>{' '}
+        that powered this site for years. You can download the{' '}
         <a
           href="https://www.github.com/circlecell/jsonlintdotcom"
           target="_blank"

--- a/lib/error-codes.ts
+++ b/lib/error-codes.ts
@@ -1,0 +1,390 @@
+/**
+ * Catalog of every diagnostic code emitted by @jsonlint/core.
+ *
+ * Drives the /errors/{CODE} reference pages and the code badges rendered by the
+ * validator. Keep this in sync with the engine (node_modules/@jsonlint/core):
+ * every code the engine can emit must have an entry here, or its badge links to
+ * a 404.
+ */
+
+export type Severity = 'error' | 'warning';
+
+export interface ErrorCodeEntry {
+  code: string;
+  severity: Severity;
+  /** Short human title, e.g. "Trailing comma". */
+  title: string;
+  /** One-sentence summary of what the diagnostic means. */
+  summary: string;
+  /** A paragraph explaining why it happens and what JSON requires. */
+  explanation: string;
+  /** Minimal snippet that triggers the code, and a corrected version. */
+  example: { bad: string; good?: string };
+  /** One-sentence fix. */
+  fix: string;
+}
+
+export const ERROR_CODES: Record<string, ErrorCodeEntry> = {
+  E001: {
+    code: 'E001',
+    severity: 'error',
+    title: 'Unexpected character',
+    summary: 'A character appeared that is not part of JSON syntax.',
+    explanation:
+      'JSON only allows a fixed set of characters outside of strings: braces, brackets, colons, commas, digits, and the literals true/false/null. A stray symbol such as @, #, or a smart punctuation mark stops the parser.',
+    example: { bad: '{ "price": @19.99 }', good: '{ "price": 19.99 }' },
+    fix: 'Remove or replace the stray character with valid JSON syntax.',
+  },
+  E002: {
+    code: 'E002',
+    severity: 'error',
+    title: 'Trailing content after the JSON value',
+    summary: 'Extra content appears after the top-level value ended.',
+    explanation:
+      'A JSON document contains exactly one top-level value. If more tokens follow — often two objects pasted back to back, or newline-delimited JSON (NDJSON) — the parser reports the leftover content.',
+    example: {
+      bad: '{ "id": 1 }{ "id": 2 }',
+      good: '[{ "id": 1 }, { "id": 2 }]',
+    },
+    fix: 'Wrap multiple values in an array, or split them into separate documents.',
+  },
+  E003: {
+    code: 'E003',
+    severity: 'error',
+    title: 'Unexpected identifier',
+    summary: 'A bare word was found where a value was expected.',
+    explanation:
+      'Unquoted words are not JSON values. Only true, false, and null are allowed as bare literals; anything else must be wrapped in double quotes to be a string.',
+    example: { bad: '{ "status": active }', good: '{ "status": "active" }' },
+    fix: 'Quote the word to make it a string, or use true/false/null.',
+  },
+  E004: {
+    code: 'E004',
+    severity: 'error',
+    title: 'Unexpected end of input',
+    summary: 'The document ended while a value was still expected.',
+    explanation:
+      'This usually means the JSON was truncated — cut off by a size limit, a failed copy/paste, or a stream that closed early — so a value that should follow a comma or colon is missing.',
+    example: { bad: '{ "items": [1, 2,', good: '{ "items": [1, 2] }' },
+    fix: 'Complete the missing value and close any open objects or arrays.',
+  },
+  E005: {
+    code: 'E005',
+    severity: 'error',
+    title: 'Expected a value',
+    summary: 'Punctuation appeared where a value belongs.',
+    explanation:
+      'After a colon or a comma the parser expects a value (string, number, object, array, or literal). Finding a closing brace, bracket, or another comma instead means a value was left out.',
+    example: { bad: '{ "name": }', good: '{ "name": null }' },
+    fix: 'Supply the missing value, or remove the dangling colon/comma.',
+  },
+  E006: {
+    code: 'E006',
+    severity: 'error',
+    title: 'Unclosed object or array',
+    summary: 'An object or array was opened but never closed.',
+    explanation:
+      'Every { must be matched by a } and every [ by a ]. The parser reached the end of the input with a container still open, usually because a closing bracket was dropped.',
+    example: { bad: '{ "user": { "name": "Ada" }', good: '{ "user": { "name": "Ada" } }' },
+    fix: 'Add the missing closing bracket to match every opening one.',
+  },
+  E007: {
+    code: 'E007',
+    severity: 'error',
+    title: 'Leading comma in object',
+    summary: 'An object starts with a comma before its first member.',
+    explanation:
+      'Commas separate members; they do not precede the first one. A leading comma is usually left behind after deleting the original first property.',
+    example: { bad: '{ , "a": 1 }', good: '{ "a": 1 }' },
+    fix: 'Delete the comma before the first member.',
+  },
+  E008: {
+    code: 'E008',
+    severity: 'error',
+    title: 'Trailing comma',
+    summary: 'A comma appears before a closing brace or bracket.',
+    explanation:
+      'Standard JSON (RFC 8259) does not allow a comma after the last element of an object or array. Trailing commas are valid in JSONC and JSON5, which is why editors often leave them behind.',
+    example: { bad: '{ "a": 1, "b": 2, }', good: '{ "a": 1, "b": 2 }' },
+    fix: 'Remove the trailing comma, or parse the input in JSONC mode if it is a config file.',
+  },
+  E009: {
+    code: 'E009',
+    severity: 'error',
+    title: 'Missing comma between items',
+    summary: "Expected ',' or a closing bracket between two values.",
+    explanation:
+      'Object members and array elements must be separated by commas. When one value is directly followed by another with no comma between them, the parser cannot tell where the first ends.',
+    example: { bad: '{ "a": 1 "b": 2 }', good: '{ "a": 1, "b": 2 }' },
+    fix: 'Add a comma between the two values.',
+  },
+  E010: {
+    code: 'E010',
+    severity: 'error',
+    title: 'Strings must use double quotes',
+    summary: "A string was written with single quotes (').",
+    explanation:
+      "JSON strings — both keys and values — must use double quotes. Single-quoted strings are valid in JavaScript and JSON5 but not in JSON or JSONC.",
+    example: { bad: "{ 'name': 'Ada' }", good: '{ "name": "Ada" }' },
+    fix: 'Replace single quotes with double quotes.',
+  },
+  E011: {
+    code: 'E011',
+    severity: 'error',
+    title: 'Smart quote found',
+    summary: 'A curly “smart” quote appeared where a string was expected.',
+    explanation:
+      'Word processors and chat apps often auto-replace straight quotes with typographic ones (“ ” ‘ ’). These are ordinary letters to JSON, not string delimiters, so the value is rejected.',
+    example: { bad: '{ "msg": “hello” }', good: '{ "msg": "hello" }' },
+    fix: 'Replace the curly quotes with straight double quotes (").',
+  },
+  E012: {
+    code: 'E012',
+    severity: 'error',
+    title: 'Number cannot start with + or .',
+    summary: "A number began with a leading '+' or '.'.",
+    explanation:
+      'JSON numbers may not have a leading plus sign, and a fraction must have at least one digit before the decimal point. These forms are valid in JSON5 only.',
+    example: { bad: '{ "ratio": .5 }', good: '{ "ratio": 0.5 }' },
+    fix: 'Drop the leading + and add a 0 before a leading decimal point.',
+  },
+  E013: {
+    code: 'E013',
+    severity: 'error',
+    title: 'Unterminated string',
+    summary: 'A string was opened but never closed.',
+    explanation:
+      'Every opening double quote needs a matching closing quote on the same line. A missing closing quote — or a line break inside the string — leaves it unterminated.',
+    example: { bad: '{ "greeting": "hello }', good: '{ "greeting": "hello" }' },
+    fix: 'Add the closing double quote (and escape any real line breaks as \\n).',
+  },
+  E014: {
+    code: 'E014',
+    severity: 'error',
+    title: 'Invalid \\u escape',
+    summary: 'A \\u escape was not followed by four hex digits.',
+    explanation:
+      'Unicode escapes in JSON take the form \\uXXXX, where XXXX is exactly four hexadecimal digits (0-9, a-f). Anything shorter, or with non-hex characters, is invalid.',
+    example: { bad: '{ "char": "\\u12" }', good: '{ "char": "\\u0041" }' },
+    fix: 'Provide four hex digits, e.g. \\u00e9 for é.',
+  },
+  E015: {
+    code: 'E015',
+    severity: 'error',
+    title: 'Invalid escape sequence',
+    summary: 'A backslash was followed by a character that is not a valid escape.',
+    explanation:
+      'Inside a JSON string a backslash starts an escape. Only \\" \\\\ \\/ \\b \\f \\n \\r \\t and \\uXXXX are allowed. A backslash before any other character — common in unescaped Windows paths — is an error.',
+    example: { bad: '{ "path": "C:\\Users" }', good: '{ "path": "C:\\\\Users" }' },
+    fix: 'Double every backslash, or use a valid escape sequence.',
+  },
+  E016: {
+    code: 'E016',
+    severity: 'error',
+    title: 'Unescaped control character in string',
+    summary: 'A raw control character (tab, newline, etc.) appears inside a string.',
+    explanation:
+      'Characters below U+0020 — literal tabs, newlines, and other control codes — are not allowed inside JSON strings. They must be written as escapes such as \\t or \\n.',
+    example: { bad: '{ "note": "line1<TAB>line2" }', good: '{ "note": "line1\\tline2" }' },
+    fix: 'Replace the raw control character with its escape (\\t, \\n, \\u0000-style, …).',
+  },
+  E018: {
+    code: 'E018',
+    severity: 'error',
+    title: 'Number has a leading zero',
+    summary: 'A number has an extra zero in front of it.',
+    explanation:
+      'JSON does not allow leading zeros on numbers (e.g. 007). A single 0, or 0 followed by a decimal point, is fine — but 0 followed by more digits is not.',
+    example: { bad: '{ "code": 0123 }', good: '{ "code": 123 }' },
+    fix: 'Remove the leading zero, or quote the value if you need to preserve it.',
+  },
+  E019: {
+    code: 'E019',
+    severity: 'error',
+    title: 'Malformed number',
+    summary: 'Expected a digit that is missing from a number.',
+    explanation:
+      'A JSON number needs digits after a decimal point and after an exponent marker. Forms like 1., 1e, or a lone - are incomplete.',
+    example: { bad: '{ "value": 1. }', good: '{ "value": 1.0 }' },
+    fix: 'Add the missing digit(s) to complete the number.',
+  },
+  E020: {
+    code: 'E020',
+    severity: 'error',
+    title: 'Unterminated block comment',
+    summary: 'A /* comment was never closed with */.',
+    explanation:
+      'Block comments are a JSONC/JSON5 feature (not standard JSON). When one is opened with /* but never closed, everything after it is swallowed as a comment.',
+    example: { bad: '{ /* todo\n"a": 1 }', good: '{ "a": 1 }' },
+    fix: 'Close the comment with */, or remove it and parse in JSONC mode if needed.',
+  },
+  E021: {
+    code: 'E021',
+    severity: 'error',
+    title: 'Comments are not allowed in strict JSON',
+    summary: 'A // or /* comment appeared in strict JSON.',
+    explanation:
+      'Standard JSON has no comments. They are valid in JSONC (used by tsconfig.json, VS Code settings, and similar config files), so switch to JSONC mode if this input is a config file.',
+    example: { bad: '{\n  "port": 8080 // dev\n}', good: '{\n  "port": 8080\n}' },
+    fix: 'Remove the comment, or enable JSONC mode for config files.',
+  },
+  E022: {
+    code: 'E022',
+    severity: 'error',
+    title: 'Object keys must be quoted',
+    summary: 'An object key was written without double quotes.',
+    explanation:
+      'In JSON every object key is a double-quoted string. Unquoted keys (and numeric keys) are valid in JavaScript object literals and JSON5, but not in JSON.',
+    example: { bad: '{ name: "Ada" }', good: '{ "name": "Ada" }' },
+    fix: 'Wrap the key in double quotes.',
+  },
+  E023: {
+    code: 'E023',
+    severity: 'error',
+    title: 'Expected an object key',
+    summary: 'Something other than a key appeared inside an object.',
+    explanation:
+      'After { or a comma inside an object, the parser expects a quoted key. Finding a colon, bracket, or other token there usually means a key is missing or a stray character slipped in.',
+    example: { bad: '{ : "Ada" }', good: '{ "name": "Ada" }' },
+    fix: 'Add the missing quoted key before the colon.',
+  },
+  E024: {
+    code: 'E024',
+    severity: 'error',
+    title: "Expected ':' after object key",
+    summary: 'A colon is missing between a key and its value.',
+    explanation:
+      'Object members are written as "key": value. When the colon is dropped, the parser sees the value directly after the key and cannot pair them.',
+    example: { bad: '{ "name" "Ada" }', good: '{ "name": "Ada" }' },
+    fix: 'Add a colon between the key and its value.',
+  },
+  E025: {
+    code: 'E025',
+    severity: 'error',
+    title: 'Leading byte-order mark (BOM)',
+    summary: 'The input begins with a UTF-8 BOM.',
+    explanation:
+      'Some Windows editors (Notepad, PowerShell, Visual Studio) prepend an invisible byte-order mark (U+FEFF) when saving. Strict JSON does not allow it before the first value.',
+    example: { bad: '\\uFEFF{ "a": 1 }', good: '{ "a": 1 }' },
+    fix: 'Save the file as UTF-8 without BOM, or parse in JSONC mode where it is a warning.',
+  },
+  E026: {
+    code: 'E026',
+    severity: 'error',
+    title: 'Input is UTF-16/UTF-32 encoded',
+    summary: 'The bytes look like UTF-16 or UTF-32, not UTF-8.',
+    explanation:
+      'JSON should be encoded as UTF-8. Files saved as "Unicode" by some Windows tools are actually UTF-16, which shows up as null bytes between characters and cannot be parsed as UTF-8.',
+    example: { bad: '(file saved as UTF-16/"Unicode")', good: '(re-save the file as UTF-8)' },
+    fix: 'Re-save or convert the input to UTF-8.',
+  },
+  E027: {
+    code: 'E027',
+    severity: 'error',
+    title: 'Invalid UTF-8 byte',
+    summary: 'A byte in the input is not valid UTF-8.',
+    explanation:
+      'This usually means Latin-1 or Windows-1252 text (for example a “smart” dash or an accented character) was pasted or read without converting it to UTF-8 first.',
+    example: { bad: '(Latin-1 / Windows-1252 bytes)', good: '(re-encode the input as UTF-8)' },
+    fix: 'Re-encode the input as UTF-8 before validating.',
+  },
+  E030: {
+    code: 'E030',
+    severity: 'error',
+    title: 'Language literal is not valid JSON',
+    summary: 'A Python/JavaScript literal such as True, None, or undefined was used.',
+    explanation:
+      'JSON booleans and null are lowercase: true, false, null. Values copied from Python (True, False, None) or JavaScript (undefined) are not valid JSON.',
+    example: { bad: '{ "ok": True, "data": None }', good: '{ "ok": true, "data": null }' },
+    fix: 'Use lowercase true/false, and null instead of None or undefined.',
+  },
+  E031: {
+    code: 'E031',
+    severity: 'error',
+    title: 'NaN or Infinity is not valid JSON',
+    summary: 'A NaN or Infinity value was used.',
+    explanation:
+      'JSON has no representation for NaN, Infinity, or -Infinity. They are valid in JSON5 only. Serializers usually emit these by accident when a computation overflows or divides by zero.',
+    example: { bad: '{ "amount": Infinity }', good: '{ "amount": null }' },
+    fix: 'Replace it with null or a string, or fix the value before serializing.',
+  },
+  E040: {
+    code: 'E040',
+    severity: 'error',
+    title: 'Maximum nesting depth exceeded',
+    summary: 'The JSON is nested more deeply than the parser allows.',
+    explanation:
+      'To guard against stack-overflow attacks, the engine limits nesting depth (512 levels by default). Legitimate data rarely nests this deeply; hitting the limit often signals a cycle or malformed input.',
+    example: { bad: '[[[[[[ … 600 levels … ]]]]]]', good: '(flatten or restructure the data)' },
+    fix: 'Reduce the nesting depth, or raise the maxDepth option if the data is genuinely this deep.',
+  },
+  W001: {
+    code: 'W001',
+    severity: 'warning',
+    title: 'Leading byte-order mark (BOM)',
+    summary: 'The input begins with a UTF-8 BOM (allowed in JSONC).',
+    explanation:
+      'In JSONC mode a leading byte-order mark (U+FEFF) is tolerated rather than rejected, but it is still non-standard and can trip up other parsers downstream.',
+    example: { bad: '\\uFEFF{ "a": 1 }', good: '{ "a": 1 }' },
+    fix: 'Save the file as UTF-8 without BOM to be safe across all tools.',
+  },
+  W017: {
+    code: 'W017',
+    severity: 'warning',
+    title: 'Lone surrogate in \\u escape',
+    summary: 'A \\u escape encodes half of a surrogate pair.',
+    explanation:
+      'Characters above U+FFFF are written as two \\u escapes (a surrogate pair). A single, unpaired surrogate is technically accepted by JSON.parse, but the resulting string contains an invalid code unit that many systems will corrupt or reject.',
+    example: { bad: '{ "emoji": "\\uD83D" }', good: '{ "emoji": "\\uD83D\\uDE00" }' },
+    fix: 'Provide the full surrogate pair, or use the actual Unicode character.',
+  },
+  W050: {
+    code: 'W050',
+    severity: 'warning',
+    title: 'Integer loses precision',
+    summary: 'A large integer exceeds JavaScript’s safe range.',
+    explanation:
+      'JavaScript numbers are IEEE-754 doubles, so integers beyond 2^53 (9,007,199,254,740,992) cannot be represented exactly. Large IDs such as Twitter/X snowflake IDs silently round to a different value when parsed as numbers.',
+    example: {
+      bad: '{ "id": 12345678901234567890 }',
+      good: '{ "id": "12345678901234567890" }',
+    },
+    fix: 'Store large IDs as strings, or parse with a lossless-number option.',
+  },
+  W051: {
+    code: 'W051',
+    severity: 'warning',
+    title: 'Control escape in a Windows path',
+    summary: 'An escape like \\t is a control character in what looks like a path.',
+    explanation:
+      'In a string, \\t is a TAB, \\n a newline, and \\b a backspace — not a backslash followed by a letter. A value like "C:\\temp" therefore contains a tab and a partial path, which is almost never intended.',
+    example: { bad: '{ "dir": "C:\\temp" }', good: '{ "dir": "C:\\\\temp" }' },
+    fix: 'Double every backslash so the path is literal: C:\\\\temp.',
+  },
+  W060: {
+    code: 'W060',
+    severity: 'warning',
+    title: 'Duplicate object key',
+    summary: 'The same key appears more than once in one object.',
+    explanation:
+      'JSON does not forbid duplicate keys, but the result is ambiguous: most parsers keep only the last occurrence and silently discard the earlier values. This is almost always a mistake.',
+    example: {
+      bad: '{ "id": 1, "id": 2 }',
+      good: '{ "id": 2 }',
+    },
+    fix: 'Remove or rename the duplicate so each key appears once.',
+  },
+};
+
+/** All codes, errors first then warnings, each group in numeric order. */
+export function getAllErrorCodes(): ErrorCodeEntry[] {
+  return Object.values(ERROR_CODES).sort((a, b) => {
+    if (a.severity !== b.severity) return a.severity === 'error' ? -1 : 1;
+    return a.code.localeCompare(b.code);
+  });
+}
+
+/** Case-insensitive lookup; returns null for unknown codes. */
+export function getErrorCode(code: string): ErrorCodeEntry | null {
+  return ERROR_CODES[code.toUpperCase()] ?? null;
+}

--- a/lib/jsonlint-core-integration.ts
+++ b/lib/jsonlint-core-integration.ts
@@ -1,0 +1,49 @@
+/**
+ * Adapter around @jsonlint/core — the engine that powers the main validator.
+ *
+ * `lint()` runs the single-pass diagnostics engine and returns every error and
+ * warning at once, each with a 1-based line/column resolved from its offset.
+ * Warnings (duplicate keys, precision loss, lone surrogates, Windows-path
+ * escapes) do not make a document invalid — `ok` reflects errors only.
+ *
+ * Source: github.com/toddynho/jsonlint-core (packages/core).
+ */
+import { validate, lineColumn, type Diagnostic } from '@jsonlint/core';
+
+export type LintMode = 'strict' | 'jsonc';
+
+export interface LintDiagnostic extends Omit<Diagnostic, 'related'> {
+  line: number;
+  column: number;
+  related:
+    | (NonNullable<Diagnostic['related']> & { line: number; column: number })
+    | null;
+}
+
+export interface LintResult {
+  ok: boolean;
+  ms: number;
+  diagnostics: LintDiagnostic[];
+}
+
+/** Run the core engine and return render-ready diagnostics. */
+export function lint(
+  text: string,
+  { mode = 'strict' }: { mode?: LintMode } = {}
+): LintResult {
+  const now = () =>
+    typeof performance !== 'undefined' ? performance.now() : 0;
+  const t0 = now();
+  const { ok, diagnostics } = validate(text, { mode });
+  return {
+    ok,
+    ms: now() - t0,
+    diagnostics: diagnostics.map((d) => {
+      const { line, column } = lineColumn(text, d.start);
+      const related = d.related
+        ? { ...d.related, ...lineColumn(text, d.related.start) }
+        : null;
+      return { ...d, line, column, related };
+    }),
+  };
+}

--- a/lib/shadow-telemetry.ts
+++ b/lib/shadow-telemetry.ts
@@ -1,0 +1,54 @@
+/**
+ * Client-side sample telemetry for the validator.
+ *
+ * Post-flip, @jsonlint/core is authoritative, so there is no legacy comparison
+ * to make. This records a 10% sample of real validations carrying only
+ * aggregate signal — the distinct error codes, document length, diagnostic
+ * count, and engine latency. The document itself never leaves the browser.
+ *
+ * Feeds the code-frequency and latency queries in workers/shadow/QUERIES.md.
+ * Telemetry failures are swallowed: this can never affect a user's validation.
+ */
+import type { LintResult, LintMode } from './jsonlint-core-integration';
+
+const ENDPOINT = '/api/shadow';
+const SAMPLE_RATE = 0.1; // 10% of validations report code + latency stats
+
+function send(payload: Record<string, unknown>): void {
+  try {
+    if (typeof navigator === 'undefined' || !navigator.sendBeacon) return;
+    const body = new Blob([JSON.stringify(payload)], {
+      type: 'application/json',
+    });
+    navigator.sendBeacon(ENDPOINT, body);
+  } catch {
+    /* telemetry must never affect the user */
+  }
+}
+
+/**
+ * Record a sampled telemetry point for a validation that already ran.
+ * Pass the `LintResult` from `lint()` so no second parse is needed.
+ */
+export function recordValidationSample(
+  result: LintResult,
+  textLength: number,
+  mode: LintMode = 'strict'
+): void {
+  try {
+    if (Math.random() >= SAMPLE_RATE) return;
+    const codes = Array.from(new Set(result.diagnostics.map((d) => d.code)));
+    send({
+      kind: 'sample',
+      mode,
+      len: textLength,
+      coreMs: Math.round(result.ms * 10) / 10,
+      coreOk: result.ok,
+      firstCode: result.diagnostics[0]?.code ?? '',
+      codes: codes.slice(0, 8).join(','),
+      diagCount: result.diagnostics.length,
+    });
+  } catch {
+    /* never throw into the validation path */
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jsonlint.com",
       "version": "2.0.0",
       "dependencies": {
+        "@jsonlint/core": "^0.1.0",
         "@monaco-editor/react": "^4.6.0",
         "@shikijs/monaco": "^3.20.0",
         "@shikijs/rehype": "^3.20.0",
@@ -333,6 +334,15 @@
       },
       "peerDependencies": {
         "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsonlint/core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@jsonlint/core/-/core-0.1.0.tgz",
+      "integrity": "sha512-HPlapzSGnTb9KNlRrSnz1nKCIOaRpgmjrgUfnVdsDuVTcoipOZHYLbA+a3XA+5tXIzJv9RyWgMjv3hdOawV4Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@monaco-editor/loader": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@jsonlint/core": "^0.1.0",
     "@monaco-editor/react": "^4.6.0",
     "@shikijs/monaco": "^3.20.0",
     "@shikijs/rehype": "^3.20.0",

--- a/workers/shadow/QUERIES.md
+++ b/workers/shadow/QUERIES.md
@@ -1,0 +1,74 @@
+# Analyzing the sample telemetry (Analytics Engine SQL API)
+
+Query via <https://developers.cloudflare.com/analytics/analytics-engine/sql-api/>:
+
+```bash
+curl "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT}/analytics_engine/sql" \
+  -H "Authorization: Bearer $CF_TOKEN" \
+  -d "SELECT ..."
+```
+
+**Column map** (matches `shadow-worker.js`):
+`blob1=firstCode`, `blob2=mode`, `blob3=coreOk ("1"/"0")`, `blob4=codes`,
+`double1=len`, `double2=diagCount`, `double3=coreMs`, `index1=kind ("sample")`.
+
+Each row is a 10% sample of a real validation. Scale counts by ~10 for
+absolute traffic estimates.
+
+## 1. Daily sample volume (sanity check the pipeline is flowing)
+
+```sql
+SELECT toDate(timestamp) AS day, count() AS samples
+FROM jsonlint_shadow
+GROUP BY day ORDER BY day
+```
+
+## 2. Error-code frequency on real traffic — prioritizes /errors/CODE pages + hints
+
+```sql
+SELECT arrayJoin(splitByChar(',', blob4)) AS code, count() AS n
+FROM jsonlint_shadow
+WHERE blob4 != ''
+GROUP BY code ORDER BY n DESC
+```
+
+Which errors humans actually hit decides the order to invest in `/errors/{CODE}`
+pages and which hints earn their keep. Nobody else has this dataset.
+
+## 3. Valid vs invalid split (how much traffic is already-clean JSON)
+
+```sql
+SELECT blob3 AS core_ok, count() AS n
+FROM jsonlint_shadow
+GROUP BY core_ok
+```
+
+## 4. Engine latency on real documents (p50/p95/p99 by size bucket)
+
+```sql
+SELECT multiIf(double1 < 10000, '<10KB', double1 < 1000000, '<1MB', '>=1MB') AS size,
+       quantile(0.5)(double3) AS p50_ms,
+       quantile(0.95)(double3) AS p95_ms,
+       quantile(0.99)(double3) AS p99_ms,
+       count() AS n
+FROM jsonlint_shadow
+GROUP BY size ORDER BY size
+```
+
+Production p95 by size answers "do we need the WASM build yet?" with data
+instead of guesses.
+
+## 5. First-error distribution (which error users see first, before fixing)
+
+```sql
+SELECT blob1 AS first_code, count() AS n
+FROM jsonlint_shadow
+WHERE blob1 != ''
+GROUP BY first_code ORDER BY n DESC
+```
+
+---
+
+_Note: this is the post-flip, sample-only kit. @jsonlint/core is already the
+authoritative validator, so there is no legacy-vs-core divergence stream — the
+original kit's divergence queries do not apply here._

--- a/workers/shadow/README.md
+++ b/workers/shadow/README.md
@@ -1,0 +1,34 @@
+# Shadow sample telemetry
+
+Document-free sample telemetry for the JSONLint validator: a 10% sample of real
+validations carrying only the distinct error codes, document length, diagnostic
+count, and engine latency. The document itself never leaves the browser.
+
+- **Client:** [`lib/shadow-telemetry.ts`](../../lib/shadow-telemetry.ts) —
+  `recordValidationSample()` is called from `handleValidate` in
+  `components/JsonValidator.tsx` with the `LintResult` already computed (no second
+  parse). Beacons to `/api/shadow`.
+- **Collector:** `shadow-worker.js` — writes to a Cloudflare Analytics Engine
+  dataset. Whitelists + clamps every field.
+- **Analysis:** [`QUERIES.md`](./QUERIES.md) — code frequency, latency
+  percentiles, valid/invalid split, first-error distribution.
+
+## What is sent
+
+`kind`, `mode`, `len` (chars), `coreMs`, `coreOk`, `firstCode`, `codes` (≤8
+distinct), `diagCount`. **Never** the document text. No gating is applied — to
+honor Do Not Track / Global Privacy Control instead, add an early
+`if (navigator.doNotTrack === '1' || navigator.globalPrivacyControl) return;`
+guard at the top of `recordValidationSample`.
+
+## Deploy (your step — needs your Cloudflare creds)
+
+```bash
+cd workers/shadow
+npx wrangler deploy
+```
+
+The route `jsonlint.com/api/shadow` and the `jsonlint_shadow` Analytics Engine
+dataset are declared in `wrangler.toml`. Analytics Engine needs no provisioning
+and is free at this volume. Once deployed, run the queries in `QUERIES.md` via
+the SQL API.

--- a/workers/shadow/shadow-worker.js
+++ b/workers/shadow/shadow-worker.js
@@ -1,0 +1,65 @@
+// Cloudflare Worker: sample-telemetry collector for jsonlint.com.
+//
+// Receives the document-free samples emitted by lib/shadow-telemetry.ts and
+// writes them to a Cloudflare Analytics Engine dataset (free at this volume,
+// no database, SQL-queryable). See wrangler.toml for the binding + route.
+//
+// Privacy/robustness: only a fixed, whitelisted set of scalar fields is stored,
+// and every field is clamped. The client never sends document content, and this
+// worker would drop it anyway — unknown fields are ignored entirely.
+//
+// Column layout (keep in sync with QUERIES.md):
+//   index1 = kind ("sample")
+//   blob1 = firstCode   blob2 = mode   blob3 = coreOk ("1"/"0")   blob4 = codes
+//   double1 = len       double2 = diagCount   double3 = coreMs
+
+export default {
+  async fetch(request, env) {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: cors() });
+    }
+    if (request.method !== 'POST') {
+      return new Response(null, { status: 405, headers: cors() });
+    }
+
+    let b;
+    try {
+      b = await request.json();
+    } catch {
+      return new Response(null, { status: 400, headers: cors() });
+    }
+
+    const str = (v, max) => (typeof v === 'string' ? v.slice(0, max) : '');
+    const num = (v, max) =>
+      typeof v === 'number' && isFinite(v)
+        ? Math.min(Math.max(v, -1), max)
+        : -1;
+
+    env.SHADOW.writeDataPoint({
+      indexes: ['sample'], // sampling key; only one kind is emitted post-flip
+      blobs: [
+        str(b.firstCode, 8), // e.g. "W060"
+        str(b.mode, 8), // "strict" | "jsonc"
+        b.coreOk === true ? '1' : b.coreOk === false ? '0' : '', // valid?
+        str(b.codes, 64), // distinct codes, e.g. "E009,W060"
+      ],
+      doubles: [
+        num(b.len, 100_000_000), // document length (chars)
+        num(b.diagCount, 1000), // number of diagnostics
+        num(b.coreMs, 60_000), // engine runtime, ms
+      ],
+    });
+
+    return new Response(null, { status: 204, headers: cors() });
+  },
+};
+
+function cors() {
+  // Same-origin in production (jsonlint.com/api/shadow), so this is belt-and-
+  // suspenders; keeps local/dev cross-origin beacons from erroring.
+  return {
+    'access-control-allow-origin': 'https://jsonlint.com',
+    'access-control-allow-methods': 'POST, OPTIONS',
+    'access-control-allow-headers': 'content-type',
+  };
+}

--- a/workers/shadow/wrangler.toml
+++ b/workers/shadow/wrangler.toml
@@ -1,0 +1,15 @@
+name = "jsonlint-shadow"
+main = "shadow-worker.js"
+compatibility_date = "2024-11-01"
+
+# Route the collector at the same origin as the site so the browser beacon is a
+# plain same-origin POST (no CORS preflight). Adjust the zone if needed.
+routes = [
+  { pattern = "jsonlint.com/api/shadow", zone_name = "jsonlint.com" }
+]
+
+# Analytics Engine dataset the worker writes to. Query it via the SQL API
+# (see QUERIES.md). No database to provision; free at this volume.
+[[analytics_engine_datasets]]
+binding = "SHADOW"
+dataset = "jsonlint_shadow"


### PR DESCRIPTION
## Summary
Replaces the legacy `JSON.parse`-based validator with **@jsonlint/core** as the authoritative engine for the main validator. A single pass now surfaces every error and warning at once, each with a precise line/column, rendered as a diagnostics list.

## What's included
- **Engine flip** — `lib/jsonlint-core-integration.ts` (`lint()` adapter); `components/JsonValidator.tsx` renders all diagnostics at once with error-code badges. Legacy `parseJSON` still backs secondary ops (Prettify/Compress/Sort/stats) and the other tools.
- **Error-code reference pages** — `lib/error-codes.ts` catalogs all 34 codes; `/errors` index + `/errors/[code]` SSG pages; diagnostic badges link to them; added to the sitemap.
- **Powered-by** — credit line under the validator, and homepage Credits updated (maintainer → Todd Garland; keeps historical credit to Crockford + Zach Carter).
- **Sample telemetry** — `lib/shadow-telemetry.ts` sends a 10% document-free sample (distinct codes + length + engine latency) to `/api/shadow`; Cloudflare Worker + SQL queries in `workers/shadow/`. Worker not deployed.

## Verification
- `tsc --noEmit` clean; `npm run build` passes (all 34 error pages prerendered).
- Browser-tested: multi-error and valid-with-warning cases; telemetry beacon fires ~10% and payloads confirmed document-free.

## Notes
- `@jsonlint/core` bundled via npm (not the CDN import alternative).
- Telemetry has no consent gating (low-PII: codes + numbers only, never the document); a DNT/GPC guard is a one-line add noted in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)