### PR TITLE
Support draft 2019-09 / 2020-12 in the JSON Schema validator

### DIFF
--- a/app/json-schema/JsonSchemaValidator.tsx
+++ b/app/json-schema/JsonSchemaValidator.tsx
@@ -4,6 +4,23 @@ import { useState } from 'react';
 import { JsonEditor } from '@/components/JsonEditor';
 import { parseJSON } from '@/lib/json-utils';
 import Ajv, { ErrorObject } from 'ajv';
+import Ajv2019 from 'ajv/dist/2019';
+import Ajv2020 from 'ajv/dist/2020';
+
+// Ajv's default build only registers the draft-07 meta-schema, so schemas
+// declaring a newer `$schema` (2019-09 / 2020-12) fail to compile. Pick the
+// matching Ajv build from the schema's declared draft. See issue #13.
+function createAjvForSchema(schema: unknown): Ajv {
+  const draft =
+    schema && typeof schema === 'object' && '$schema' in schema &&
+    typeof (schema as { $schema?: unknown }).$schema === 'string'
+      ? (schema as { $schema: string }).$schema
+      : '';
+  const options = { allErrors: true };
+  if (draft.includes('2020-12')) return new Ajv2020(options);
+  if (draft.includes('2019-09')) return new Ajv2019(options);
+  return new Ajv(options); // draft-07 / draft-06 / unspecified
+}
 
 const exampleSchema = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -49,7 +66,7 @@ export function JsonSchemaValidator() {
     }
 
     try {
-      const ajv = new Ajv({ allErrors: true });
+      const ajv = createAjvForSchema(schemaResult.data);
       const validate = ajv.compile(schemaResult.data as object);
       const valid = validate(dataResult.data);
 


### PR DESCRIPTION
Closes #13.

## Problem
The `/json-schema` tool called `new Ajv()`, which is Ajv's **draft-07** build. Its meta-schema registry doesn't include 2019-09 or 2020-12, so any schema declaring `"$schema": "https://json-schema.org/draft/2020-12/schema"` failed at `compile()` with:

```
no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
```

(This is unrelated to the `@jsonlint/core` engine — that powers JSON *syntax* validation; this tool uses `ajv` for *schema* validation.)

## Fix
Detect the draft from the schema's `$schema` and pick the matching Ajv build:
- `.../2020-12/schema` → `Ajv2020` (`ajv/dist/2020`)
- `.../2019-09/schema` → `Ajv2019` (`ajv/dist/2019`)
- draft-07 / draft-06 / unspecified → the default `Ajv`

All three ship inside the installed `ajv` v8 — **no new dependency**.

## Verification (live)
- The 2020-12 example from the issue → **Valid! Data matches the schema.**
- A violating payload (`{ "age": -5 }`) → **Invalid! 2 errors**: `must have required property 'name'`, `/age must be >= 0`.
- `tsc --noEmit` clean.

Note: draft-04 would still need the separate `ajv-draft-04` package; out of scope here but easy to add if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)